### PR TITLE
Cleanup and update CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,6 @@ on:
       - main
     tags:
       - '*'
-  pull_request:
-    branches:
-      - main
 env:
   CRATER_VERSION: 1.0.0
 jobs:

--- a/package/docker/customStart.sh
+++ b/package/docker/customStart.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-./start.sh


### PR DESCRIPTION
This PR removes the customStart.sh script which is no longer needed as per the latest workaround. It also removes the condition to run CI for pull requests as it generates a docker image for every PR.