### PR TITLE
BAH-2194 Bug Fix Udated the mandatory roles required

### DIFF
--- a/database/seeders/json/roles.json
+++ b/database/seeders/json/roles.json
@@ -11,6 +11,7 @@
             "create-item",
             "edit-item",
             "delete-item",
+            "view-tax-type",
             "view-estimate",
             "create-estimate",
             "edit-estimate",
@@ -26,8 +27,10 @@
             "edit-payment",
             "delete-payment",
             "send-payment",
+            "view-custom-field",
             "view-financial-reports",
-            "dashboard"
+            "dashboard",
+            "view-all-notes"
         ]                
     },
     {
@@ -40,6 +43,7 @@
             "view-item",
             "create-item",
             "edit-item",
+            "view-tax-type",
             "view-estimate",
             "create-estimate",
             "edit-estimate",
@@ -52,7 +56,9 @@
             "create-payment",
             "edit-payment",
             "delete-payment",
-            "send-payment"
+            "send-payment",
+            "view-custom-field",
+            "view-all-notes"
         ]           
     }
 ]


### PR DESCRIPTION
Added the additional roles required to perform the actions needed by Doctor & front desk roles.

The roles created by custom seeders do not have enough privileges to create invoices, and errors are displayed on the Create invoice and View payments page. 

Found that the below mandatory privileges are required in order to create an invoice and added them in JSON file.
- view-tax-type
- view-custom-field
- view-all-notes


Bug card - User with front desk & doctor role is not able to create invoice in the crater
https://bahmni.atlassian.net/browse/BAH-2194
