### PR TITLE
[Rahul] | BAH-3005 | Add. Timezone Global Value For Helm Charts

### DIFF
--- a/package/helm/crater/templates/configMap.yaml
+++ b/package/helm/crater/templates/configMap.yaml
@@ -15,3 +15,4 @@ data:
   COMPANY_NAME: "{{ .Values.config.COMPANY_NAME }}"
   COMPANY_SLUG: "{{ .Values.config.COMPANY_SLUG }}"
   COUNTRY_ID: "{{ .Values.config.COUNTRY_ID }}"
+  TZ: "{{ .Values.global.TZ }}"

--- a/package/helm/crater/values.yaml
+++ b/package/helm/crater/values.yaml
@@ -3,6 +3,7 @@ global:
   affinity: {}
   tolerations: {}
   storageClass: ""
+  TZ: "UTC"
 
 nginxReplicaCount: 1
 


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to the helm charts to configure the timezone for the [crater-extensions](https://github.com/Bahmni/crater-extensions) container.